### PR TITLE
Added in support to hide the PayPal logo in the Android actionbar

### DIFF
--- a/src/android/CardIO.java
+++ b/src/android/CardIO.java
@@ -21,7 +21,7 @@ import android.content.Intent;
 
 
 public class CardIO extends CordovaPlugin {
-    
+
     public CallbackContext callbackContext;
     public static JSONObject cardNumber = null;
     public static Boolean expiry;
@@ -30,14 +30,15 @@ public class CardIO extends CordovaPlugin {
     public static Boolean confirm;
     public static Boolean hideLogo;
     public static Boolean suppressManual;
-    
+    public static Boolean usePaypalIcon;
+
     @Override
     public boolean execute(String action, JSONArray args,
                            CallbackContext callbackContext) {
-        
+
         // TODO Auto-generated method stub
         this.callbackContext = callbackContext;
-        
+
         try {
             // set configurations
             if( action.equals("scan") ) {
@@ -48,11 +49,12 @@ public class CardIO extends CordovaPlugin {
                 confirm = config.getBoolean("suppressConfirm");
                 hideLogo = config.getBoolean("hideLogo");
                 suppressManual = config.getBoolean("suppressManual");
-            
+                usePaypalIcon = config.getBoolean("usePaypalIcon");
+
                 Intent scanIntent = new Intent(cordova.getActivity(),
                                            CardIOMain.class);
                 cordova.getActivity().startActivity(scanIntent);
-            
+
                 PluginResult cardData = new PluginResult(
                                                      PluginResult.Status.NO_RESULT);
                 cardData.setKeepCallback(true);
@@ -70,19 +72,19 @@ public class CardIO extends CordovaPlugin {
             return false;
         } catch (JSONException e) {
             e.printStackTrace();
-            
+
             PluginResult res = new PluginResult(
                                                 PluginResult.Status.JSON_EXCEPTION);
             callbackContext.sendPluginResult(res);
             return false;
         }
-        
+
     }
-    
+
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        
+
         // send plugin result if success
         JSONObject mImagepath = cardNumber;
         if (mImagepath != null) {
@@ -97,6 +99,6 @@ public class CardIO extends CordovaPlugin {
             cardData.setKeepCallback(false);
             callbackContext.sendPluginResult(cardData);
         }
-        
+
     }
 }

--- a/src/android/CardIOMain.java
+++ b/src/android/CardIOMain.java
@@ -19,38 +19,39 @@ import android.content.Intent;
 import android.os.Bundle;
 
 public class CardIOMain extends Activity {
-    
+
     private static int MY_SCAN_REQUEST_CODE=10;
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         //		setContentView(R.layout.activity_main);
-        
+
         Intent scanIntent = new Intent(CardIOMain.this, CardIOActivity.class);
-        
+
+        scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, CardIO.hideLogo);
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_EXPIRY, CardIO.expiry);
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_CVV, CardIO.cvv);
         scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_POSTAL_CODE, CardIO.zip);
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION, CardIO.confirm);
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_MANUAL_ENTRY, CardIO.suppressManual);
-        scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, CardIO.hideLogo);
-        
+        scanIntent.putExtra(CardIOActivity.EXTRA_USE_PAYPAL_ACTIONBAR_ICON, CardIO.usePaypalIcon);
+
         // MY_SCAN_REQUEST_CODE is arbitrary and is only used within this activity.
         startActivityForResult(scanIntent, MY_SCAN_REQUEST_CODE);
     }
-    
-    
+
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        
+
         if (requestCode == MY_SCAN_REQUEST_CODE) {
             if (data != null && data.hasExtra(CardIOActivity.EXTRA_SCAN_RESULT)) {
                 CreditCard scanResult = data.getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT);
-                
+
                 JSONObject cardObj = new JSONObject();
-                
+
                 try {
                     cardObj.put("card_number",scanResult.cardNumber);
                     cardObj.put("card_type",scanResult.getCardType().getDisplayName("en-US"));
@@ -59,25 +60,25 @@ public class CardIOMain extends Activity {
                         cardObj.put("expiry_month",scanResult.expiryMonth);
                         cardObj.put("expiry_year",scanResult.expiryYear);
                     }
-                    
+
                     if (scanResult.cvv != null) {
                         cardObj.put("cvv",scanResult.cvv);
-                        
+
                     }
-                    
+
                     if (scanResult.postalCode != null) {
                         cardObj.put("zip",scanResult.postalCode);
                     }
-                    
+
                 } catch (JSONException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
                 }
-                
+
                 CardIO.cardNumber = cardObj;
             }
         }
         CardIOMain.this.finish();
     }
-    
+
 }

--- a/src/ios/CardIOCordovaPlugin.m
+++ b/src/ios/CardIOCordovaPlugin.m
@@ -48,7 +48,7 @@
         paymentViewController.collectExpiry = [collectExpiry boolValue];
     }
 
-    NSNumber *disableManualEntryButtons = [options objectForKey:@"supressManual"];
+    NSNumber *disableManualEntryButtons = [options objectForKey:@"suppressManual"];
     if(disableManualEntryButtons) {
         paymentViewController.disableManualEntryButtons = [disableManualEntryButtons boolValue];
     }
@@ -57,12 +57,12 @@
     if(suppressConfirm) {
         paymentViewController.suppressScanConfirmation = [suppressConfirm boolValue];
     }
-    
+
     NSNumber *hideLogo = [options objectForKey:@"hideLogo"];
     if(hideLogo) {
         paymentViewController.hideCardIOLogo = [hideLogo boolValue];
     }
-    
+
     // if it is nil, its ok.
     NSString *languageOrLocale = [[[NSLocale alloc] initWithLocaleIdentifier:[options objectForKey:@"languageOrLocale"]] localeIdentifier];
     if (languageOrLocale) {


### PR DESCRIPTION
Leveraging a configuration option of the underlying Android native code, we added in support to set this option via the plugin.
