### PR TITLE
Fix sendFailureTo using wrong CDVCommandStatus

### DIFF
--- a/src/ios/CardIOCordovaPlugin.m
+++ b/src/ios/CardIOCordovaPlugin.m
@@ -57,12 +57,12 @@
     if(suppressConfirm) {
         paymentViewController.suppressScanConfirmation = [suppressConfirm boolValue];
     }
-    
+
     NSNumber *hideLogo = [options objectForKey:@"hideLogo"];
     if(hideLogo) {
         paymentViewController.hideCardIOLogo = [hideLogo boolValue];
     }
-    
+
     // if it is nil, its ok.
     NSString *languageOrLocale = [[[NSLocale alloc] initWithLocaleIdentifier:[options objectForKey:@"languageOrLocale"]] localeIdentifier];
     if (languageOrLocale) {
@@ -146,7 +146,7 @@
 }
 
 - (void)sendFailureTo:(NSString *)callbackId {
-    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
     [self.commandDelegate sendPluginResult:result callbackId:callbackId];
 }
 


### PR DESCRIPTION
- `CDVCommandStatus_OK` -> `CDVCommandStatus_ERROR`
- cancel button now uses the correct callback

I had noticed that the cancel button and any subsequent error wasn't correctly firing the call on the JS front end, and was occasionally hitting some errors that seemed to only exist if the scan completed successfully.

It appears that the sendFailureTo function was giving `CDVCommandStatus_OK` when it should have been giving `CDVCommandStatus_ERROR`.

Thanks for keeping this plugin up to date, great to see the community active and hopefully this will save a few hairs from being pulled out.
