### PR TITLE
Add callback for failure on CardIO.canScan method

### DIFF
--- a/www/cdv-plugin-card-io.js
+++ b/www/cdv-plugin-card-io.js
@@ -40,8 +40,9 @@ CardIO.prototype.scan = function(options, onSuccess, onFailure) {
  *
  * @parameter callback: a callback function accepting a boolean.
  */
-CardIO.prototype.canScan = function(callback) {
+CardIO.prototype.canScan = function(callback, failCallback) {
   var failureCallback = function() {
+    failCallback()
     console.log("Could not detect whether card.io card scanning is available.");
   };
   var wrappedSuccess = function(response) {


### PR DESCRIPTION
Add a callback when the CardIO plugin can't detect whether card.io card scanning is available. Right now you only show a console.log
