### PR TITLE
Fix "Error: Invalid character in entity name"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     id="com.keepe.cardio"
     version="1.0.9">
     <name>CardIO</name>
-    <description>This plugin allows to add CardIO to your application using CardIO Native library. Supports iOS & Android</description>
+    <description>This plugin allows to add CardIO to your application using CardIO Native library. Supports iOS &amp; Android</description>
     <license>MIT License, see LICENSE.md for details</license>
     <keywords>cordova, card scan, scanner, card.io</keywords>
     <engines>


### PR DESCRIPTION
Cordova 6.5.0 was giving me the business when I tried to install this plugin:

```
Error: Invalid character in entity name
Line: 8
Column: 114
Char:
```

Escaping the ampersand in plugin.xml fixed it for me.